### PR TITLE
Added that the compass gem must be installed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ It is a refreshed implementation of [cidar](https://github.com/patforna/cidar).
 ```
    git clone https://github.com/lplotni/burstah.git
    cd burstah
+   sudo gem install compass
    npm install
    nohup npm start &
 ```

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -24,8 +24,20 @@ body .footer .name {
     background: #ef5ba1;
   }
 }
+
+@-moz-keyframes building {
+  0% {
+    background: #26bdcf;
+  }
+
+  100% {
+    background: #ef5ba1;
+  }
+}
+
 .building {
   -webkit-animation: building 2s ease-out 0s infinite alternate;
+  -moz-animation: building 2s ease-out 0s infinite alternate;
 }
 
 .stage {

--- a/public/stylesheets/style.scss
+++ b/public/stylesheets/style.scss
@@ -24,8 +24,14 @@ body {
   100%  {background: rgb(239,91,161);}
 }
 
+@-moz-keyframes building {
+  0%   {background: rgb(38,189,207);}
+  100%  {background: rgb(239,91,161);}
+}
+
 .building {
-  -webkit-animation: building 2s ease-out 0s infinite alternate;
+    -webkit-animation: building 2s ease-out 0s infinite alternate;
+    -moz-animation: building 2s ease-out 0s infinite alternate;
 }
 //END
 


### PR DESCRIPTION
It looks like this only works when you have the compass gem installed. We tried on an OS X machine and an Amazon Linux instance and in both cases the app crashed with the following error message just after serving the full HTML but before serving the other assets.
    
    GET / 200 1455ms - 4.69kb
    
    events.js:72
            throw er; // Unhandled 'error' event
                  ^
    Error: spawn ENOENT
        at errnoException (child_process.js:1011:11)
        at Process.ChildProcess._handle.onexit (child_process.js:802:34)
    
Installing the compass gem fixed the problems on both machines. Seems like this is a somewhat common problem: http://stackoverflow.com/questions/25090140/spawn-enoent-node-js-error
