### PR TITLE
Replace pulsing colors by progress stripes when building

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -17,27 +17,49 @@ body .footer .name {
 
 @-webkit-keyframes building {
   0% {
-    background: #26bdcf;
+    background-position: 0 0;
   }
-
   100% {
-    background: #ef5ba1;
+    background-position: 50px 50px;
   }
 }
-
 @-moz-keyframes building {
   0% {
-    background: #26bdcf;
+    background-position: 0 0;
   }
-
   100% {
-    background: #ef5ba1;
+    background-position: 50px 50px;
   }
 }
-
+@-ms-keyframes building {
+  0% {
+    background-position: 0 0;
+  }
+  100% {
+    background-position: 50px 50px;
+  }
+}
+@keyframes building {
+  0% {
+    background-position: 0 0;
+  }
+  100% {
+    background-position: 50px 50px;
+  }
+}
 .building {
-  -webkit-animation: building 2s ease-out 0s infinite alternate;
-  -moz-animation: building 2s ease-out 0s infinite alternate;
+  background-image: -webkit-linear-gradient(-45deg, #a0a0a0 25%, transparent 25%, transparent 50%, #a0a0a0 50%, #a0a0a0 75%, transparent 75%, transparent);
+  background-image: -moz-linear-gradient(-45deg, #a0a0a0 25%, transparent 25%, transparent 50%, #a0a0a0 50%, #a0a0a0 75%, transparent 75%, transparent);
+  background-image: -ms-linear-gradient(-45deg, #a0a0a0 25%, transparent 25%, transparent 50%, #a0a0a0 50%, #a0a0a0 75%, transparent 75%, transparent);
+  background-image: linear-gradient(-45deg, #a0a0a0 25%, rgba(0, 0, 0, 0) 25%, rgba(0, 0, 0, 0) 50%, #a0a0a0 50%, #a0a0a0 75%, rgba(0, 0, 0, 0) 75%, rgba(0, 0, 0, 0));
+  -webkit-background-size: 50px 50px;
+  -moz-background-size: 50px 50px;
+  -ms-background-size: 50px 50px;
+  background-size: 50px 50px;
+  -webkit-animation: building 2s linear infinite;
+  -moz-animation: building 2s linear infinite;
+  -ms-animation: building 2s linear infinite;
+  animation: building 2s linear infinite;
 }
 
 .stage {

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -19,22 +19,83 @@ body {
 }
 
 //CSS animtation for ongoing build
-@-webkit-keyframes building {
-  0%   {background: rgb(38,189,207);}
-  100%  {background: rgb(239,91,161);}
+@mixin building-keyframes() {
+  0% {
+    background-position: 0 0;
+  }
+  100% {
+    background-position: 50px 50px;
+  }
 }
-
+@-webkit-keyframes building {
+  @include building-keyframes();
+}
 @-moz-keyframes building {
-  0%   {background: rgb(38,189,207);}
-  100%  {background: rgb(239,91,161);}
+  @include building-keyframes();
+}
+@-ms-keyframes building {
+  @include building-keyframes();
+}
+@keyframes building {
+  @include building-keyframes();
 }
 
 .building {
-    -webkit-animation: building 2s ease-out 0s infinite alternate;
-    -moz-animation: building 2s ease-out 0s infinite alternate;
+  $overlay-color: rgba(160, 160, 160, 1);
+  background-image:
+    -webkit-linear-gradient(
+      -45deg,
+      $overlay-color 25%,
+      transparent 25%,
+      transparent 50%,
+      $overlay-color 50%,
+      $overlay-color 75%,
+      transparent 75%,
+      transparent
+    );
+  background-image:
+    -moz-linear-gradient(
+      -45deg,
+      $overlay-color 25%,
+      transparent 25%,
+      transparent 50%,
+      $overlay-color 50%,
+      $overlay-color 75%,
+      transparent 75%,
+      transparent
+    );
+  background-image:
+    -ms-linear-gradient(
+      -45deg,
+      $overlay-color 25%,
+      transparent 25%,
+      transparent 50%,
+      $overlay-color 50%,
+      $overlay-color 75%,
+      transparent 75%,
+      transparent
+    );
+  background-image:
+    linear-gradient(
+      -45deg,
+      $overlay-color 25%,
+      transparent 25%,
+      transparent 50%,
+      $overlay-color 50%,
+      $overlay-color 75%,
+      transparent 75%,
+      transparent
+    );
+  -webkit-background-size:50px 50px;
+  -moz-background-size:50px 50px;
+  -ms-background-size:50px 50px;
+  background-size:50px 50px;
+  -webkit-animation:building 2s linear infinite;
+  -moz-animation:building 2s linear infinite;
+  -ms-animation:building 2s linear infinite;
+  animation:building 2s linear infinite;
 }
 //END
-
 
 .stage {
   width: 49%;


### PR DESCRIPTION
Previously a stage was pulsing with fixed colors while building. This
hid the outcome of the last build. It was not visible whether the build
had been successful or not.

Now the stage is overlaid with gray progress stripes while building. The
outcome of the last build is still clearly visible (green or red).

Furthermore the CSS effects are now working on IE (prefixed `-ms`) and
standards-compliant browsers as well (without prefix).

NB: some statements are currently duplicated for each browser specific
prefix. There might be a SASS way of reducing this duplication.
